### PR TITLE
[CARE-4368] Display embargo timezone as UTC offset

### DIFF
--- a/modules/Story/Embargo/Embargo.tsx
+++ b/modules/Story/Embargo/Embargo.tsx
@@ -1,3 +1,4 @@
+import { Culture } from '@prezly/sdk';
 import { translations } from '@prezly/theme-kit-intl';
 import { FormattedDate, FormattedMessage, FormattedTime } from 'react-intl';
 
@@ -11,6 +12,7 @@ type Props = {
 
 function Embargo({ story }: Props) {
     const { timezone } = story.newsroom;
+    const date = new Date(story.published_at);
 
     return (
         <div className={styles.embargo}>
@@ -20,19 +22,25 @@ function Embargo({ story }: Props) {
                     date: (
                         <>
                             <FormattedDate
-                                value={new Date(story.published_at)}
+                                value={date}
                                 year="numeric"
                                 month="long"
                                 day="numeric"
                                 timeZone={timezone}
                             />{' '}
                             <FormattedTime
-                                value={new Date(story.published_at)}
+                                value={date}
                                 hour="2-digit"
                                 minute="2-digit"
-                                timeZoneName="short"
                                 timeZone={timezone}
-                            />
+                            />{' '}
+                            UTC
+                            {date
+                                .toLocaleString(Culture.isoCode(story.culture.code), {
+                                    timeZoneName: 'longOffset',
+                                    timeZone: timezone,
+                                })
+                                .replace(/^.*? GMT/, '')}
                         </>
                     ),
                 }}


### PR DESCRIPTION
![Screenshot 2024-03-26 at 14 19 48](https://github.com/prezly/theme-nextjs-lena/assets/4209081/27992283-5966-4c82-b43f-e379fe64cce2)
