### PR TITLE
Fix - Gallery card image overflowing and search results appearing blurry

### DIFF
--- a/components/GalleryCard/GalleryCard.module.scss
+++ b/components/GalleryCard/GalleryCard.module.scss
@@ -10,6 +10,7 @@
 }
 
 .thumbnail {
+    width: 100%;
     margin: 0 auto;
     border-top-left-radius: $border-radius-lg;
     border-top-right-radius: $border-radius-lg;

--- a/utils/getImageSizes.ts
+++ b/utils/getImageSizes.ts
@@ -3,7 +3,7 @@ export type CardSize = 'default' | 'big' | 'tiny';
 
 export function getCardImageSizes(cardSize: CardSize) {
     if (cardSize === 'tiny') {
-        return '60px';
+        return '100px';
     }
 
     return [


### PR DESCRIPTION
Just fixing some things I've noticed in production.