### PR TITLE
[CARE-5201] Feature - Allow communication between the theme and the parent

### DIFF
--- a/components/WindowScrollListener/WindowScrollListener.tsx
+++ b/components/WindowScrollListener/WindowScrollListener.tsx
@@ -1,0 +1,43 @@
+import { useEffect } from 'react';
+
+type OnScrollMessage = {
+    type: 'onScroll';
+    value: number;
+};
+
+type ScrollToMessage = {
+    type: 'scrollTo';
+    value: number;
+};
+
+export function WindowScrollListener() {
+    useEffect(() => {
+        function onScroll() {
+            window.parent.postMessage(
+                {
+                    type: 'onScroll',
+                    value: window.scrollY,
+                } satisfies OnScrollMessage,
+                '*',
+            );
+        }
+
+        window.addEventListener('scroll', onScroll);
+
+        return () => window.removeEventListener('scroll', onScroll);
+    }, []);
+
+    useEffect(() => {
+        function onMessage(event: MessageEvent<ScrollToMessage>) {
+            if (event.data.type === 'scrollTo') {
+                window.scrollTo({ top: event.data.value });
+            }
+        }
+
+        window.addEventListener('message', onMessage);
+
+        return () => window.removeEventListener('message', onMessage);
+    }, []);
+
+    return null;
+}

--- a/components/WindowScrollListener/index.ts
+++ b/components/WindowScrollListener/index.ts
@@ -1,0 +1,1 @@
+export { WindowScrollListener } from './WindowScrollListener';

--- a/modules/Layout/Layout.tsx
+++ b/modules/Layout/Layout.tsx
@@ -14,6 +14,7 @@ import { useEffect, useMemo, useState } from 'react';
 
 import { CategoriesBar, NotificationsBar } from '@/components';
 import { PreviewPageMask } from '@/components/PreviewPageMask';
+import { WindowScrollListener } from '@/components/WindowScrollListener';
 import { LoadingBar, ScrollToTopButton } from '@/ui';
 
 import Boilerplate from './Boilerplate';
@@ -125,6 +126,7 @@ function Layout({ children, description, imageUrl, title, hasError }: PropsWithC
             {/* hide scroll to top on story page */}
             {!STORY_PAGE_PATHS.includes(pathname) && <ScrollToTopButton />}
             <PreviewPageMask />
+            <WindowScrollListener />
         </>
     );
 }


### PR DESCRIPTION
We need to be able to preserve the scroll position when live previewing the theme, but since it's not possible to access the scroll position of the iframe, we need this extra code to provide the scroll position when scrolling happens.

Similarly, we also need to listen to the messages from the parent so we can restore the scroll position after the iframe is reloaded.